### PR TITLE
Add checkout and order history features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,12 @@
         <activity
             android:name=".ui.cart.CartActivity"
             android:exported="false" />
+        <activity
+            android:name=".ui.order.CheckoutActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ui.order.OrderHistoryActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/foodordersystem/ui/cart/CartActivity.java
+++ b/app/src/main/java/com/example/foodordersystem/ui/cart/CartActivity.java
@@ -45,7 +45,7 @@ public class CartActivity extends AppCompatActivity implements CartItemAdapter.C
         loadCartItems();
 
         btnCheckout.setOnClickListener(v ->
-                Toast.makeText(this, "Tiến hành thanh toán...", Toast.LENGTH_SHORT).show());
+                startActivity(new android.content.Intent(this, com.example.foodordersystem.ui.order.CheckoutActivity.class)));
     }
 
     private void loadCartItems() {

--- a/app/src/main/java/com/example/foodordersystem/ui/order/CheckoutActivity.java
+++ b/app/src/main/java/com/example/foodordersystem/ui/order/CheckoutActivity.java
@@ -1,0 +1,101 @@
+package com.example.foodordersystem.ui.order;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.foodordersystem.R;
+import com.example.foodordersystem.data.dao.CartDao;
+import com.example.foodordersystem.data.dao.MenuDao;
+import com.example.foodordersystem.data.dao.OrderDao;
+import com.example.foodordersystem.data.dao.OrderInfoDao;
+import com.example.foodordersystem.data.database.DatabaseClient;
+import com.example.foodordersystem.data.entity.CartItem;
+import com.example.foodordersystem.data.entity.MenuItem;
+import com.example.foodordersystem.data.entity.Order;
+import com.example.foodordersystem.data.entity.OrderInfo;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Executors;
+
+public class CheckoutActivity extends AppCompatActivity {
+
+    private TextView txtMessage;
+    private Button btnHistory;
+    private int userId;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_checkout);
+
+        txtMessage = findViewById(R.id.txtCheckoutMessage);
+        btnHistory = findViewById(R.id.btnViewHistory);
+
+        SharedPreferences prefs = getSharedPreferences("UserPrefs", MODE_PRIVATE);
+        userId = prefs.getInt("userId", -1);
+
+        processCheckout();
+
+        btnHistory.setOnClickListener(v ->
+                startActivity(new Intent(this, OrderHistoryActivity.class)));
+    }
+
+    private void processCheckout() {
+        Executors.newSingleThreadExecutor().execute(() -> {
+            DatabaseClient client = DatabaseClient.getInstance(this);
+            CartDao cartDao = client.getAppDatabase().cartDao();
+            MenuDao menuDao = client.getAppDatabase().menuDao();
+            OrderDao orderDao = client.getAppDatabase().orderDao();
+            OrderInfoDao orderInfoDao = client.getAppDatabase().orderInfoDao();
+
+            List<CartItem> cartItems = cartDao.getCartItemsByUser(userId);
+            if (cartItems.isEmpty()) {
+                runOnUiThread(() -> txtMessage.setText("Giỏ hàng trống"));
+                return;
+            }
+
+            double total = 0;
+            for (CartItem item : cartItems) {
+                MenuItem menuItem = menuDao.getMenuItemById(item.itemId);
+                if (menuItem != null) {
+                    total += menuItem.price * item.quantity;
+                }
+            }
+
+            Order order = new Order();
+            order.userId = userId;
+            order.orderDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(new Date());
+            order.totalPrice = total;
+            order.status = "Pending";
+            orderDao.insertOrder(order);
+
+            List<Order> orders = orderDao.getOrdersByUser(userId);
+            int orderId = orders.get(orders.size() - 1).orderId;
+
+            for (CartItem item : cartItems) {
+                MenuItem menuItem = menuDao.getMenuItemById(item.itemId);
+                if (menuItem != null) {
+                    OrderInfo info = new OrderInfo();
+                    info.orderId = orderId;
+                    info.itemId = item.itemId;
+                    info.quantity = item.quantity;
+                    info.priceAtOrder = menuItem.price;
+                    orderInfoDao.insert(info);
+                }
+            }
+
+            cartDao.clearCart(userId);
+
+            runOnUiThread(() -> txtMessage.setText("Đặt hàng thành công"));
+        });
+    }
+}

--- a/app/src/main/java/com/example/foodordersystem/ui/order/OrderHistoryActivity.java
+++ b/app/src/main/java/com/example/foodordersystem/ui/order/OrderHistoryActivity.java
@@ -1,0 +1,45 @@
+package com.example.foodordersystem.ui.order;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.foodordersystem.R;
+import com.example.foodordersystem.data.dao.OrderDao;
+import com.example.foodordersystem.data.database.DatabaseClient;
+import com.example.foodordersystem.data.entity.Order;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+
+public class OrderHistoryActivity extends AppCompatActivity {
+
+    private RecyclerView recyclerView;
+    private int userId;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_order_history);
+
+        recyclerView = findViewById(R.id.recyclerOrders);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        SharedPreferences prefs = getSharedPreferences("UserPrefs", MODE_PRIVATE);
+        userId = prefs.getInt("userId", -1);
+
+        loadOrders();
+    }
+
+    private void loadOrders() {
+        Executors.newSingleThreadExecutor().execute(() -> {
+            OrderDao orderDao = DatabaseClient.getInstance(this).getAppDatabase().orderDao();
+            List<Order> orders = orderDao.getOrdersByUser(userId);
+            runOnUiThread(() -> recyclerView.setAdapter(new OrderHistoryAdapter(orders)));
+        });
+    }
+}

--- a/app/src/main/java/com/example/foodordersystem/ui/order/OrderHistoryAdapter.java
+++ b/app/src/main/java/com/example/foodordersystem/ui/order/OrderHistoryAdapter.java
@@ -1,0 +1,56 @@
+package com.example.foodordersystem.ui.order;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.foodordersystem.R;
+import com.example.foodordersystem.data.entity.Order;
+
+import java.util.List;
+
+public class OrderHistoryAdapter extends RecyclerView.Adapter<OrderHistoryAdapter.OrderViewHolder> {
+
+    private final List<Order> orders;
+
+    public OrderHistoryAdapter(List<Order> orders) {
+        this.orders = orders;
+    }
+
+    @NonNull
+    @Override
+    public OrderViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_order_history, parent, false);
+        return new OrderViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull OrderViewHolder holder, int position) {
+        Order order = orders.get(position);
+        holder.txtId.setText("Mã đơn: " + order.orderId);
+        holder.txtDate.setText(order.orderDate);
+        holder.txtTotal.setText(String.format("%.0f đ", order.totalPrice));
+        holder.txtStatus.setText(order.status);
+    }
+
+    @Override
+    public int getItemCount() {
+        return orders.size();
+    }
+
+    static class OrderViewHolder extends RecyclerView.ViewHolder {
+        TextView txtId, txtDate, txtTotal, txtStatus;
+
+        OrderViewHolder(@NonNull View itemView) {
+            super(itemView);
+            txtId = itemView.findViewById(R.id.txtOrderId);
+            txtDate = itemView.findViewById(R.id.txtOrderDate);
+            txtTotal = itemView.findViewById(R.id.txtOrderTotal);
+            txtStatus = itemView.findViewById(R.id.txtOrderStatus);
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_checkout.xml
+++ b/app/src/main/res/layout/activity_checkout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/txtCheckoutMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Processing..." />
+
+    <Button
+        android:id="@+id/btnViewHistory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Lịch sử đơn" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_order_history.xml
+++ b/app/src/main/res/layout/activity_order_history.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerOrders"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_order_history.xml
+++ b/app/src/main/res/layout/item_order_history.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:layout_margin="8dp"
+    android:background="#FFFFFF"
+    android:elevation="2dp">
+
+    <TextView
+        android:id="@+id/txtOrderId"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/txtOrderDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/txtOrderTotal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/txtOrderStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- implement `CheckoutActivity` to create orders from cart contents
- clear the cart after creating an order
- list previous orders with `OrderHistoryActivity`
- show order history using a new adapter
- hook checkout button to launch checkout flow
- add required layouts and manifest entries

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a766f30832ba6e24c214ce79b8d